### PR TITLE
fix syntax error

### DIFF
--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -20,23 +20,23 @@ class GoogleAuthenticator {
 	 * @return [type]         [description]
 	 */
 	public function getQRData($name, $secret, $title = null, $params = array()) {
-		$urlencoded = 'otpauth://totp/' . urlencode($name) . '?secret=' . $secret . '');
+		$urlencoded = 'otpauth://totp/' . urlencode($name) . '?secret=' . $secret . '';
 		if (isset($title)) {
-			$urlencoded .= '&issuer=' . urlencode($title));
+			$urlencoded .= '&issuer=' . urlencode($title);
 		}
 		return $urlencoded;
 	}
 
-	/**
-	 * 获取验证二维码， 默认返回base64图片数据，
-	 * @param  String      $name     [description]
-	 * @param  String      $secret   [description]
-	 * @param  String|null $title    [description]
-	 * @param  int|integer $ret_type [返回类型  默认1 base64数据； 0 直接输出； 2 写入到文件]
-	 * @param  String|null $out_file [$ret_type=2时的写入图片文件全路径]
-	 * @return [type]                [description]
-	 */
-	public function getQRCode(String $name, String $secret, String $title = null, int $ret_type = 1, String $out_file = null) {
+    /**
+     * 获取验证二维码， 默认返回base64图片数据，
+     * @param String        $name [description]
+     * @param String        $secret [description]
+     * @param String|null   $title [description]
+     * @param int|integer   $ret_type [返回类型  默认1 base64数据； 0 直接输出； 2 写入到文件]
+     * @param String|null   $out_file [$ret_type=2时的写入图片文件全路径]
+     * @return String|String [type]                [description]
+     */
+	public function getQRCode($name, $secret, $title = null, $ret_type = 0, $out_file = null) {
 		$urlencoded = 'otpauth://totp/' . urlencode($name) . '?secret=' . $secret;
 		if (isset($title)) {
 			$urlencoded .= '&issuer=' . urlencode($title);


### PR DESCRIPTION
Hi tekintian!
  尽管PHP5.6已经越来越过时，但是composer.json中写了，我觉得有必要支持（我仍旧在用）。
  so我在php5.6版本下发现了如下一些问题：
1.语法上多写了一个括号
PHP Parse error:  syntax error, unexpected ')' in /google-authenticator/src/GoogleAuthenticator.php on line 23
PHP Parse error:  syntax error, unexpected ')' in /google-authenticator/src/GoogleAuthenticator.php on line 25
2.上面三个问题在于，php5.6版本下不能直接声明一个传入参数的基础类型，如果声明了一个自定义的类型，那么默认值必须为null
PHP Fatal error:  Default value for parameters with a class type hint can only be NULL in /google-authenticator/src/GoogleAuthenticator.php on line 39

PHP Catchable fatal error:  Argument 1 passed to tekintian\GoogleAuthenticator::getQRCode() must be an instance of tekintian\String, string given, called in /google-authenticator/demo.php on line 23 and defined in /google-authenticator/src/GoogleAuthenticator.php on line 39

PHP Fatal error:  Default value for parameters with a class type hint can only be NULL in /google-authenticator/vendor/tekintian/phpqrcode/src/TekinQR.php on line 23

  另外有一个小建议，GoogleAuthenticator.php Line 85:20处，random_bytes在php7.0才声明，但是php的官方社区提供了一个php<7.0的方案：paragonie/random_compat ,可以考虑用这个替代掉 $rnd 返回false的可能性
